### PR TITLE
Address recent ISO C++17 changes

### DIFF
--- a/src/spams.h
+++ b/src/spams.h
@@ -32,26 +32,26 @@ typedef int int32_t;
 #include<iostream>
 /* from linalg */
 
-template<typename T> void _sort(Vector<T> *v,bool mode) throw(const char *){
+template<typename T> void _sort(Vector<T> *v,bool mode) noexcept(false) {
   v->sort(mode);
 }
 
 
-template<typename T> void _AAt(SpMatrix<T> *A,Matrix<T> *B) throw(const char *) {
+template<typename T> void _AAt(SpMatrix<T> *A,Matrix<T> *B) noexcept(false) {
   
   if(A->m() != B->m() || B->m() != B->n())
     throw("AAt: incompatible dimensions of result matrix");
   A->AAt((Matrix<T>&)(*B));
 }
 
-template<typename T> void _XAt(SpMatrix<T> *A,Matrix<T> *X,Matrix<T> *XAt) throw(const char *) {
+template<typename T> void _XAt(SpMatrix<T> *A,Matrix<T> *X,Matrix<T> *XAt) noexcept(false) {
   if(X->n() != A->n() || X->m() != XAt->m() || A->m() != XAt->n())
     throw("XAt: incompatible dimensions of result matrix");
   A->XAt((Matrix<T>&)(*X),(Matrix<T>&)(*XAt));
 }
 
 template<typename T> inline void _mult(Matrix<T> *X,Matrix<T> *Y,Matrix<T> *XY,const bool transX, const bool transY,
-      const T a, const T b) throw(const char *) {
+      const T a, const T b) noexcept(false) {
   int xrows, xcols, yrows, ycols;
   if(transX) {
     xrows = X->n();
@@ -73,11 +73,11 @@ template<typename T> inline void _mult(Matrix<T> *X,Matrix<T> *Y,Matrix<T> *XY,c
   X->mult((Matrix<T>&)(*Y),(Matrix<T>&)(*XY),transX,transY,a,b);
 }
   
-template<typename T> void _applyBayerPattern(Vector<T> *v,int offset) throw(const char *){
+template<typename T> void _applyBayerPattern(Vector<T> *v,int offset) noexcept(false){
   v->applyBayerPattern(offset);
 }
 
-template<typename T> void _conjugateGradient(Matrix<T> *A,Vector<T> *b,Vector<T> *x,const T tol,const int itermax) throw(const char *){
+template<typename T> void _conjugateGradient(Matrix<T> *A,Vector<T> *b,Vector<T> *x,const T tol,const int itermax) noexcept(false){
   if(A->n() != x->n() || A->m() != b->n())
     throw("conjugateGradient: incompatible matrix and vectore sizes");
   A->conjugateGradient((Vector<T> &)(*b),(Vector<T> &)(*x),tol,itermax);
@@ -98,7 +98,7 @@ template<typename T> void _normalize(Matrix<T> *A) {
 template <typename T> inline void _sparseProject(Matrix<T> *U,Matrix<T> *V,
       const T thrs,   const int mode, const T lambda1,
       const T lambda2, const T lambda3, const bool pos,
-      const int numThreads) throw(const char *) {
+      const int numThreads) noexcept(false) {
   if(U->m() != V->m() || U->n() != V->n())
     throw("sparseProject: incompatible matrices");
   U->sparseProject((Matrix<T>&)(*V),thrs,mode,lambda1,lambda2,lambda3,pos,numThreads);
@@ -109,7 +109,7 @@ SpMatrix<T> *_lassoD(Matrix<T> *X, Matrix<T> *D,Matrix<T> **path,bool return_reg
 		    int L, const T constraint, const T lambda2, constraint_type mode,
       const bool pos, const bool ols, const int numThreads,
 		    int max_length_path,const bool verbose, bool cholevsky) 
-throw(const char *) 
+noexcept(false) 
 {
   SpMatrix<T> *alpha = new SpMatrix<T>();
   int n = X->m();
@@ -147,7 +147,7 @@ SpMatrix<T> *_lassoQq(Matrix<T> *X, Matrix<T> *Q, Matrix<T> *q,Matrix<T> **path,
 		      int L, const T constraint, const T lambda2, constraint_type mode,
 		      const bool pos, const bool ols, const int numThreads,
 		      int max_length_path,const bool verbose, bool cholevsky) 
-throw(const char *) 
+noexcept(false) 
 // lambda2 is ignored
 {
   SpMatrix<T> *alpha = new SpMatrix<T>();
@@ -191,7 +191,7 @@ template <typename T>
 SpMatrix<T> *_lassoMask(Matrix<T> *X, Matrix<T> *D,Matrix<bool> *B,
 		    int L, const T constraint, const T lambda2, constraint_type mode,
 			const bool pos, const int numThreads,bool verbose) 
-throw(const char *) 
+noexcept(false) 
 {
   SpMatrix<T> *alpha = new SpMatrix<T>();
   int n = X->m();
@@ -218,7 +218,7 @@ template <typename T>
 SpMatrix<T> *_lassoWeighted(Matrix<T> *X, Matrix<T> *D,Matrix<T> *W,
 		    int L, const T constraint, constraint_type mode,
 			const bool pos, const int numThreads,bool verbose) 
-throw(const char *) 
+noexcept(false) 
 {
   SpMatrix<T> *alpha = new SpMatrix<T>();
   int n = X->m();
@@ -248,7 +248,7 @@ throw(const char *)
 }
 
 template <typename T>
-SpMatrix<T> *_omp(Matrix<T> *X,Matrix<T> *D,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) throw(const char *){
+SpMatrix<T> *_omp(Matrix<T> *X,Matrix<T> *D,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) noexcept(false){
   SpMatrix<T> *alpha = new SpMatrix<T>();
     int n = X->m();
     int nD = D->m();
@@ -293,7 +293,7 @@ SpMatrix<T> *_omp(Matrix<T> *X,Matrix<T> *D,Matrix<T> **path,bool return_reg_pat
 }
 
 template <typename T>
-SpMatrix<T> *_ompMask(Matrix<T> *X,Matrix<T> *D,Matrix<bool> *B,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) throw(const char *){
+SpMatrix<T> *_ompMask(Matrix<T> *X,Matrix<T> *D,Matrix<bool> *B,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) noexcept(false){
   SpMatrix<T> *alpha = new SpMatrix<T>();
     int n = X->m();
     int M = X->n();
@@ -342,7 +342,7 @@ SpMatrix<T> *_ompMask(Matrix<T> *X,Matrix<T> *D,Matrix<bool> *B,Matrix<T> **path
     return alpha;
 }
 template <typename T>
-SpMatrix<T> *_cd(Matrix<T> *X,Matrix<T> *D,SpMatrix<T>*alpha,T lambda1, constraint_type mode, int itermax, T tol,int numThreads) throw(const char *){
+SpMatrix<T> *_cd(Matrix<T> *X,Matrix<T> *D,SpMatrix<T>*alpha,T lambda1, constraint_type mode, int itermax, T tol,int numThreads) noexcept(false){
   int n = X->m();
   int M = X->n();
   int nD = D->m();
@@ -360,7 +360,7 @@ SpMatrix<T> *_cd(Matrix<T> *X,Matrix<T> *D,SpMatrix<T>*alpha,T lambda1, constrai
 }
 
 template <typename T>
-SpMatrix<T> *_somp(Matrix<T> *X,Matrix<T> *D,Vector<int> *groups,int LL, T eps, int numThreads) throw(const char *){
+SpMatrix<T> *_somp(Matrix<T> *X,Matrix<T> *D,Vector<int> *groups,int LL, T eps, int numThreads) noexcept(false){
   int *list_groups = groups->rawX();
   int Ng = groups->n();
   int n = X->m();
@@ -416,7 +416,7 @@ SpMatrix<T> *_somp(Matrix<T> *X,Matrix<T> *D,Vector<int> *groups,int LL, T eps, 
    return alpha;
 }
 template <typename T>
-void _l1L2BCD(Matrix<T> *X,Matrix<T> *D,Matrix<T>*alpha0,Vector<int> *groups,T lambda1, constraint_type mode,int itermax,T tol,int numThreads) throw(const char *){
+void _l1L2BCD(Matrix<T> *X,Matrix<T> *D,Matrix<T>*alpha0,Vector<int> *groups,T lambda1, constraint_type mode,int itermax,T tol,int numThreads) noexcept(false){
   int n = X->m();
   int M = X->n();
   int nD = D->m();
@@ -497,7 +497,7 @@ Matrix<T> *_fistaFlat(Matrix<T> *X,AbstractMatrixB<T> *D,Matrix<T> *alpha0,
 	     bool transpose,
              int linesearch_mode
 )
-throw(const char *) 
+noexcept(false) 
 {
 using namespace FISTA;
  int mD = D->m();
@@ -649,7 +649,7 @@ Matrix<T> *_fistaTree(
 	     bool transpose,
              int linesearch_mode
 )
-throw(const char *) 
+noexcept(false) 
 {
 using namespace FISTA;
  int mD = D->m();
@@ -817,7 +817,7 @@ Matrix<T> *_fistaGraph(
 	     bool transpose,
              int linesearch_mode
 )
-throw(const char *) 
+noexcept(false) 
 {
   using namespace FISTA;
   cout << "FISTA\n";
@@ -955,7 +955,7 @@ Vector<T> *_proximalFlat(Matrix<T> *alpha0,Matrix<T> *alpha,
 		int size_group,
 		bool transpose
 		) 
-throw(const char *) 
+noexcept(false) 
 {
 using namespace FISTA;
   FISTA::ParamFISTA<T> param;
@@ -1015,7 +1015,7 @@ Vector<T> *_proximalTree(Matrix<T> *alpha0,Matrix<T> *alpha, // tree
 		int size_group,
 		bool transpose
 		) 
-throw(const char *) 
+noexcept(false) 
 {
 using namespace FISTA;
   FISTA::ParamFISTA<T> param;
@@ -1094,7 +1094,7 @@ Vector<T> *_proximalGraph(Matrix<T> *alpha0,Matrix<T> *alpha, // graph
 		int size_group,
 		bool transpose
 		) 
-throw(const char *) 
+noexcept(false) 
 {
 using namespace FISTA;
   FISTA::ParamFISTA<T> param;
@@ -1184,7 +1184,7 @@ Matrix<T> *_alltrainDL(Data<T> *X,bool in_memory, Matrix<T> **omA,Matrix<T> **om
 		    bool batch,
 		    bool log,
 		    char *logName
-		    )  throw(const char *){
+		    )  noexcept(false){
 #ifdef _OPENMP
   num_threads = num_threads <= 0 ? omp_get_num_procs() : num_threads;
 #else
@@ -1339,7 +1339,7 @@ Matrix<T> *_alltrainDL(Data<T> *X,bool in_memory, Matrix<T> **omA,Matrix<T> **om
 
 /* from dictLearn/arch */
 template <typename T>
-Matrix<T> *_archetypalAnalysisInit(Matrix<T>* X, Matrix<T>* Z0, SpMatrix<T>** spA, SpMatrix<T>** spB, bool robust, T epsilon, bool computeXtX, int stepsFISTA, int stepsAS, int numThreads) throw(const char *)  {
+Matrix<T> *_archetypalAnalysisInit(Matrix<T>* X, Matrix<T>* Z0, SpMatrix<T>** spA, SpMatrix<T>** spB, bool robust, T epsilon, bool computeXtX, int stepsFISTA, int stepsAS, int numThreads) noexcept(false)  {
   Matrix<T>* Z = new Matrix<T>(Z0->m(),Z0->n());
   *spA = new SpMatrix<T>();
   *spB = new SpMatrix<T>();
@@ -1348,7 +1348,7 @@ Matrix<T> *_archetypalAnalysisInit(Matrix<T>* X, Matrix<T>* Z0, SpMatrix<T>** sp
 }
 
 template <typename T>
-Matrix<T> *_archetypalAnalysis(Matrix<T>* X, int p, SpMatrix<T>** spA, SpMatrix<T>** spB, bool robust, T epsilon, bool computeXtX, int stepsFISTA, int stepsAS, bool randominit, int numThreads) throw(const char *) {
+Matrix<T> *_archetypalAnalysis(Matrix<T>* X, int p, SpMatrix<T>** spA, SpMatrix<T>** spB, bool robust, T epsilon, bool computeXtX, int stepsFISTA, int stepsAS, bool randominit, int numThreads) noexcept(false) {
   Matrix<T>* Z = new Matrix<T>(X->m(),p);
   *spA = new SpMatrix<T>();
   *spB = new SpMatrix<T>();
@@ -1377,7 +1377,7 @@ template <typename T>
      stored by columns.
 */
 template<typename T>
-void _im2col_sliding(Matrix<T>  *A,Matrix<T>  *B,int m, int n,bool RGB)  throw(const char *){
+void _im2col_sliding(Matrix<T>  *A,Matrix<T>  *B,int m, int n,bool RGB)  noexcept(false){
   /* if RGB is true A has 3*n columns, R G B columns are consecutives 
    */
   int mm = A->m();

--- a/src/spams.h
+++ b/src/spams.h
@@ -1357,7 +1357,7 @@ Matrix<T> *_archetypalAnalysis(Matrix<T>* X, int p, SpMatrix<T>** spA, SpMatrix<
 }
 
 template <typename T>
-  SpMatrix<T> *_decompSimplex(Matrix<T>* X, Matrix<T>* Z, bool computeXtX, int numThreads) throw(const char*){
+  SpMatrix<T> *_decompSimplex(Matrix<T>* X, Matrix<T>* Z, bool computeXtX, int numThreads) noexcept(false){
   SpMatrix<T>* alpha = new SpMatrix<T>();
   decompSimplex<T>((Matrix<T>&)(*X), (Matrix<T>&)(*Z), (SpMatrix<T>&) (*alpha), computeXtX,numThreads);
   return alpha;

--- a/src/spams/prox/groups-graph.h
+++ b/src/spams/prox/groups-graph.h
@@ -199,7 +199,7 @@ intlist(string s) {
  Return : a vector of StructNodeElem<T>
 */
 template <typename T>
-std::vector<StructNodeElem<T> *> *_groupStructOfString(const char *data) throw(const char *){
+std::vector<StructNodeElem<T> *> *_groupStructOfString(const char *data) noexcept(false){
   std::istringstream is(data);
   std::vector<StructNodeElem<T> *> *gstruct = new std::vector<StructNodeElem<T> *>;
 
@@ -224,7 +224,7 @@ std::vector<StructNodeElem<T> *> *_groupStructOfString(const char *data) throw(c
   return gstruct;
 }
 template <typename T>
-std::vector<StructNodeElem<T> *> *_readGroupStruct(const char *file) throw(const char *){
+std::vector<StructNodeElem<T> *> *_readGroupStruct(const char *file) noexcept(false){
   std::ifstream infile;
   infile.open (file, ifstream::in);
   if(! infile.good())
@@ -250,7 +250,7 @@ std::vector<StructNodeElem<T> *> *_readGroupStruct(const char *file) throw(const
  Return: StructNodeElem vector
  */
 template <typename T>
-std::vector<StructNodeElem<T> *> *_simpleGroupTree(int *degr, int n) throw(const char *){
+std::vector<StructNodeElem<T> *> *_simpleGroupTree(int *degr, int n) noexcept(false){
   std::vector<int> degrees;
   for(int i = 0;i < n;i++)
     degrees.push_back(degr[i]);
@@ -480,7 +480,7 @@ static std::vector<StructNodeElem<T> *> *reorder_group_tree(std::vector<StructNo
        the documantation of proximalTree.
  */
 template <typename T>
-Vector<T> *_graphOfGroupStruct(std::vector<StructNodeElem<T> *> *gstruct,SpMatrix<bool> **pgroups,SpMatrix<bool> **pgroups_var) throw(const char *) {
+Vector<T> *_graphOfGroupStruct(std::vector<StructNodeElem<T> *> *gstruct,SpMatrix<bool> **pgroups,SpMatrix<bool> **pgroups_var) noexcept(false) {
   int nb_vars;
   Vector<T> *peta_g;
   if (! checkGroupTree<T>(gstruct,false,&nb_vars))
@@ -565,7 +565,7 @@ Vector<T> *_graphOfGroupStruct(std::vector<StructNodeElem<T> *> *gstruct,SpMatri
    Return : nb of variables
  */
 template <typename T>
-int _treeOfGroupStruct(std::vector<StructNodeElem<T> *> *gstruct,int **pperm,int *pnb_vars,Vector<T> **peta_g,SpMatrix<bool> **pgroups,Vector<int> **pown_variables,Vector<int> **pN_own_variables) throw(const char *){
+int _treeOfGroupStruct(std::vector<StructNodeElem<T> *> *gstruct,int **pperm,int *pnb_vars,Vector<T> **peta_g,SpMatrix<bool> **pgroups,Vector<int> **pown_variables,Vector<int> **pN_own_variables) noexcept(false){
   int nb_vars;
   *pnb_vars = 0;
   if (! checkGroupTree<T>(gstruct,true,&nb_vars))


### PR DESCRIPTION
This fork deals with some basic changes related to recent compiler issues.  Tested on Mac OS X Ventura (13.4, arm64).

```
> devtools::install_github('getspams/spams-R')
Downloading GitHub repo getspams/spams-R@HEAD
── R CMD build ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file ‘/private/var/folders/1q/dqz36cq11lb5ms6247zr6l840000gn/T/Rtmpz2Mra5/remotes9e512eb41cc0/getspams-spams-R-0c812f8/DESCRIPTION’ (469ms)
─  preparing ‘spams’:
✔  checking DESCRIPTION meta-information ...
─  cleaning src
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘spams_2.6.tar.gz’
   
Installing package into ‘/Users/cjfields/Library/R/arm64/4.3/library’
(as ‘lib’ is unspecified)
* installing *source* package ‘spams’ ...
** using staged installation
** libs
using C++ compiler: ‘Apple clang version 14.0.3 (clang-1403.0.22.14.1)’
using SDK: ‘MacOSX13.3.sdk’
clang++ -arch arm64 -std=gnu++17 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG   -I/opt/homebrew/include -Xclang -fopenmp -Xclang -fopenmp   -I. -Ispams/linalg -Ispams/prox -Ispams/decomp -Ispams/dictLearn -Ispams/dags    -DUSE_BLAS_LIB -DNDEBUG -O3 -mtune=native -fPIC  -I/opt/homebrew/include -c spams.cpp -o spams.o
In file included from spams.cpp:1301:
./spams.h:35:57: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
template<typename T> void _sort(Vector<T> *v,bool mode) throw(const char *){
                                                        ^~~~~~~~~~~~~~~~~~~
./spams.h:35:57: note: use 'noexcept(false)' instead
template<typename T> void _sort(Vector<T> *v,bool mode) throw(const char *){
                                                        ^~~~~~~~~~~~~~~~~~~
                                                        noexcept(false)
./spams.h:40:61: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
template<typename T> void _AAt(SpMatrix<T> *A,Matrix<T> *B) throw(const char *) {
                                                            ^~~~~~~~~~~~~~~~~~~
./spams.h:40:61: note: use 'noexcept(false)' instead
template<typename T> void _AAt(SpMatrix<T> *A,Matrix<T> *B) throw(const char *) {
                                                            ^~~~~~~~~~~~~~~~~~~
                                                            noexcept(false)
./spams.h:47:76: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
template<typename T> void _XAt(SpMatrix<T> *A,Matrix<T> *X,Matrix<T> *XAt) throw(const char *) {
                                                                           ^~~~~~~~~~~~~~~~~~~
./spams.h:47:76: note: use 'noexcept(false)' instead
template<typename T> void _XAt(SpMatrix<T> *A,Matrix<T> *X,Matrix<T> *XAt) throw(const char *) {
                                                                           ^~~~~~~~~~~~~~~~~~~
                                                                           noexcept(false)
./spams.h:54:29: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
      const T a, const T b) throw(const char *) {
                            ^~~~~~~~~~~~~~~~~~~
./spams.h:54:29: note: use 'noexcept(false)' instead
      const T a, const T b) throw(const char *) {
                            ^~~~~~~~~~~~~~~~~~~
                            noexcept(false)
./spams.h:76:71: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
template<typename T> void _applyBayerPattern(Vector<T> *v,int offset) throw(const char *){
                                                                      ^~~~~~~~~~~~~~~~~~~
./spams.h:76:71: note: use 'noexcept(false)' instead
template<typename T> void _applyBayerPattern(Vector<T> *v,int offset) throw(const char *){
                                                                      ^~~~~~~~~~~~~~~~~~~
                                                                      noexcept(false)
./spams.h:80:116: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
template<typename T> void _conjugateGradient(Matrix<T> *A,Vector<T> *b,Vector<T> *x,const T tol,const int itermax) throw(const char *){
                                                                                                                   ^~~~~~~~~~~~~~~~~~~
./spams.h:80:116: note: use 'noexcept(false)' instead
template<typename T> void _conjugateGradient(Matrix<T> *A,Vector<T> *b,Vector<T> *x,const T tol,const int itermax) throw(const char *){
                                                                                                                   ^~~~~~~~~~~~~~~~~~~
                                                                                                                   noexcept(false)
./spams.h:101:29: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
      const int numThreads) throw(const char *) {
                            ^~~~~~~~~~~~~~~~~~~
./spams.h:101:29: note: use 'noexcept(false)' instead
      const int numThreads) throw(const char *) {
                            ^~~~~~~~~~~~~~~~~~~
                            noexcept(false)
./spams.h:112:1: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
./spams.h:112:1: note: use 'noexcept(false)' instead
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
noexcept(false)
./spams.h:150:1: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
./spams.h:150:1: note: use 'noexcept(false)' instead
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
noexcept(false)
./spams.h:194:1: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
./spams.h:194:1: note: use 'noexcept(false)' instead
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
noexcept(false)
./spams.h:221:1: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
./spams.h:221:1: note: use 'noexcept(false)' instead
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
noexcept(false)
./spams.h:251:196: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
SpMatrix<T> *_omp(Matrix<T> *X,Matrix<T> *D,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) throw(const char *){
                                                                                                                                                                                                   ^~~~~~~~~~~~~~~~~~~
./spams.h:251:196: note: use 'noexcept(false)' instead
SpMatrix<T> *_omp(Matrix<T> *X,Matrix<T> *D,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) throw(const char *){
                                                                                                                                                                                                   ^~~~~~~~~~~~~~~~~~~
                                                                                                                                                                                                   noexcept(false)
./spams.h:296:216: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
SpMatrix<T> *_ompMask(Matrix<T> *X,Matrix<T> *D,Matrix<bool> *B,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) throw(const char *){
                                                                                                                                                                                                                       ^~~~~~~~~~~~~~~~~~~
./spams.h:296:216: note: use 'noexcept(false)' instead
SpMatrix<T> *_ompMask(Matrix<T> *X,Matrix<T> *D,Matrix<bool> *B,Matrix<T> **path,bool return_reg_path,bool given_L,Vector<int>*L,bool given_eps,Vector<T>*eps,bool given_Lambda,Vector<T>*Lambda,const int numThreads) throw(const char *){
                                                                                                                                                                                                                       ^~~~~~~~~~~~~~~~~~~
                                                                                                                                                                                                                       noexcept(false)
./spams.h:345:130: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
SpMatrix<T> *_cd(Matrix<T> *X,Matrix<T> *D,SpMatrix<T>*alpha,T lambda1, constraint_type mode, int itermax, T tol,int numThreads) throw(const char *){
                                                                                                                                 ^~~~~~~~~~~~~~~~~~~
./spams.h:345:130: note: use 'noexcept(false)' instead
SpMatrix<T> *_cd(Matrix<T> *X,Matrix<T> *D,SpMatrix<T>*alpha,T lambda1, constraint_type mode, int itermax, T tol,int numThreads) throw(const char *){
                                                                                                                                 ^~~~~~~~~~~~~~~~~~~
                                                                                                                                 noexcept(false)
./spams.h:363:97: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
SpMatrix<T> *_somp(Matrix<T> *X,Matrix<T> *D,Vector<int> *groups,int LL, T eps, int numThreads) throw(const char *){
                                                                                                ^~~~~~~~~~~~~~~~~~~
./spams.h:363:97: note: use 'noexcept(false)' instead
SpMatrix<T> *_somp(Matrix<T> *X,Matrix<T> *D,Vector<int> *groups,int LL, T eps, int numThreads) throw(const char *){
                                                                                                ^~~~~~~~~~~~~~~~~~~
                                                                                                noexcept(false)
./spams.h:419:144: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
void _l1L2BCD(Matrix<T> *X,Matrix<T> *D,Matrix<T>*alpha0,Vector<int> *groups,T lambda1, constraint_type mode,int itermax,T tol,int numThreads) throw(const char *){
                                                                                                                                               ^~~~~~~~~~~~~~~~~~~
./spams.h:419:144: note: use 'noexcept(false)' instead
void _l1L2BCD(Matrix<T> *X,Matrix<T> *D,Matrix<T>*alpha0,Vector<int> *groups,T lambda1, constraint_type mode,int itermax,T tol,int numThreads) throw(const char *){
                                                                                                                                               ^~~~~~~~~~~~~~~~~~~
                                                                                                                                               noexcept(false)
./spams.h:500:1: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
./spams.h:500:1: note: use 'noexcept(false)' instead
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
noexcept(false)
./spams.h:652:1: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
./spams.h:652:1: note: use 'noexcept(false)' instead
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
noexcept(false)
./spams.h:820:1: error: ISO C++17 does not allow dynamic exception specifications [-Wdynamic-exception-spec]
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
./spams.h:820:1: note: use 'noexcept(false)' instead
throw(const char *) 
^~~~~~~~~~~~~~~~~~~
noexcept(false)
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make: *** [spams.o] Error 1
ERROR: compilation failed for package ‘spams’
* removing ‘/Users/cjfields/Library/R/arm64/4.3/library/spams’
* restoring previous ‘/Users/cjfields/Library/R/arm64/4.3/library/spams’
Warning message:
In i.p(...) :
  installation of package ‘/var/folders/1q/dqz36cq11lb5ms6247zr6l840000gn/T//Rtmpz2Mra5/file9e5132cb9934/spams_2.6.tar.gz’ had non-zero exit status
```